### PR TITLE
Fix error in reference bigbrain label giftii file path

### DIFF
--- a/scripts/bigbrain_to_fsaverage.sh
+++ b/scripts/bigbrain_to_fsaverage.sh
@@ -40,14 +40,14 @@ for hemi in L R ; do
 		cp "$inData" "$wd"/tpl-bigbrain_hemi-"$hemi"_desc-"$desc"."$gii_type".gii
 	elif [[ "$extension" == "annot" ]] ; then
 		gii_type=label
-		python "$bbwDir"/scripts/annot2gii.py "$inData" "$wd"/tpl-bigbrain_hemi-"$hemi"_desc-"$desc"."$gii_type".gii "$bbwDir"/spaces/tpl-bigbrain/tpl-bigbrain_hemi-"$hemi"_desc-Yeo2011_7Networks_N1000.label."$gii_type".gii
+		python "$bbwDir"/scripts/annot2gii.py "$inData" "$wd"/tpl-bigbrain_hemi-"$hemi"_desc-"$desc"."$gii_type".gii "$bbwDir"/spaces/tpl-bigbrain/tpl-bigbrain_hemi-"$hemi"_desc-Yeo2011_7Networks_N1000."$gii_type".gii
 	elif [[ "$extension" == "curv" ]] ; then
 		gii_type=shape
 		python "$bbwDir"/scripts/curv2gii.py "$inData" "$wd"/tpl-bigbrain_hemi-"$hemi"_desc-"$desc"."$gii_type".gii "$bbwDir"/spaces/tpl-bigbrain/tpl-bigbrain_hemi-"$hemi"_desc-Func_G1.shape.gii
 	elif [[ "$extension" == "txt" ]] ; then
 		if [[  "$interp" == "nearest" ]] ; then
 			gii_type=label
-			python "$bbwDir"/scripts/txt2gii.py "$inData" "$wd"/tpl-bigbrain_hemi-"$hemi"_desc-"$desc"."$gii_type".gii "$bbwDir"/spaces/tpl-bigbrain/tpl-bigbrain_hemi-"$hemi"_desc-Yeo2011_7Networks_N1000.label."$gii_type".gii
+			python "$bbwDir"/scripts/txt2gii.py "$inData" "$wd"/tpl-bigbrain_hemi-"$hemi"_desc-"$desc"."$gii_type".gii "$bbwDir"/spaces/tpl-bigbrain/tpl-bigbrain_hemi-"$hemi"_desc-Yeo2011_7Networks_N1000."$gii_type".gii
 		else
 			gii_type=shape
 			python "$bbwDir"/scripts/txt2gii.py "$inData" "$wd"/tpl-bigbrain_hemi-"$hemi"_desc-"$desc"."$gii_type".gii "$bbwDir"/spaces/tpl-bigbrain/tpl-bigbrain_hemi-"$hemi"_desc-Func_G1.shape.gii

--- a/scripts/fsaverage_to_bigbrain.sh
+++ b/scripts/fsaverage_to_bigbrain.sh
@@ -43,14 +43,14 @@ for hemi in L R ; do
 		cp "$inData" "$wd"/tpl-"$in_space"_hemi-"$hemi"_den-"$in_den"k_desc-"$desc"."$gii_type".gii
 	elif [[ "$extension" == "annot" ]] ; then
 		gii_type=label
-		python "$bbwDir"/scripts/annot2gii.py "$inData" "$wd"/tpl-"$in_space"_hemi-"$hemi"_den-"$in_den"k_desc-"$desc"."$gii_type".gii "$bbwDir"/spaces/tpl-bigbrain/tpl-bigbrain_hemi-"$hemi"_desc-Yeo2011_7Networks_N1000.label."$gii_type".gii
+		python "$bbwDir"/scripts/annot2gii.py "$inData" "$wd"/tpl-"$in_space"_hemi-"$hemi"_den-"$in_den"k_desc-"$desc"."$gii_type".gii "$bbwDir"/spaces/tpl-bigbrain/tpl-bigbrain_hemi-"$hemi"_desc-Yeo2011_7Networks_N1000."$gii_type".gii
 	elif [[ "$extension" == "curv" ]] ; then
 		gii_type=shape
 		python "$bbwDir"/scripts/curv2gii.py "$inData" "$wd"/tpl-"$in_space"_hemi-"$hemi"_den-"$in_den"k_desc-"$desc"."$gii_type".gii "$bbwDir"/spaces/tpl-bigbrain/tpl-bigbrain_hemi-"$hemi"_desc-Func_G1.shape.gii
 	elif [[ "$extension" == "txt" ]] ; then
 		if [[  "$interp" == "nearest" ]] ; then
 			gii_type=label
-			python "$bbwDir"/scripts/txt2gii.py "$inData" "$wd"/tpl-"$in_space"_hemi-"$hemi"_den-"$in_den"k_desc-"$desc"."$gii_type".gii "$bbwDir"/spaces/tpl-bigbrain/tpl-bigbrain_hemi-"$hemi"_desc-Yeo2011_7Networks_N1000.label."$gii_type".gii
+			python "$bbwDir"/scripts/txt2gii.py "$inData" "$wd"/tpl-"$in_space"_hemi-"$hemi"_den-"$in_den"k_desc-"$desc"."$gii_type".gii "$bbwDir"/spaces/tpl-bigbrain/tpl-bigbrain_hemi-"$hemi"_desc-Yeo2011_7Networks_N1000."$gii_type".gii
 		else
 			gii_type=shape
 			python "$bbwDir"/scripts/txt2gii.py "$inData" "$wd"/tpl-"$in_space"_hemi-"$hemi"_den-"$in_den"k_desc-"$desc"."$gii_type".gii "$bbwDir"/spaces/tpl-bigbrain/tpl-bigbrain_hemi-"$hemi"_desc-Func_G1.shape.gii

--- a/scripts/fsaverage_to_bigbrainvol.sh
+++ b/scripts/fsaverage_to_bigbrainvol.sh
@@ -46,7 +46,7 @@ for hemi in L R ; do
 	elif [[ "$extension" == "annot" ]] ; then
 		gii_type=label
 		interp_res=nearest_neighbour
-		python "$bbwDir"/scripts/annot2gii.py "$inData" "$wd"/tpl-"$in_space"_hemi-"$hemi"_den-"$in_den"k_desc-"$desc"."$gii_type".gii "$bbwDir"/spaces/tpl-bigbrain/tpl-bigbrain_hemi-"$hemi"_desc-Yeo2011_7Networks_N1000.label."$gii_type".gii
+		python "$bbwDir"/scripts/annot2gii.py "$inData" "$wd"/tpl-"$in_space"_hemi-"$hemi"_den-"$in_den"k_desc-"$desc"."$gii_type".gii "$bbwDir"/spaces/tpl-bigbrain/tpl-bigbrain_hemi-"$hemi"_desc-Yeo2011_7Networks_N1000."$gii_type".gii
 	elif [[ "$extension" == "curv" ]] ; then
 		gii_type=shape
 		interp_res=trilinear
@@ -55,7 +55,7 @@ for hemi in L R ; do
 		if [[  "$interp" == "nearest" ]] ; then
 			gii_type=label
 			interp_res=nearest_neighbour
-			python "$bbwDir"/scripts/txt2gii.py "$inData" "$wd"/tpl-"$in_space"_hemi-"$hemi"_den-"$in_den"k_desc-"$desc"."$gii_type".gii "$bbwDir"/spaces/tpl-bigbrain/tpl-bigbrain_hemi-"$hemi"_desc-Yeo2011_7Networks_N1000.label."$gii_type".gii
+			python "$bbwDir"/scripts/txt2gii.py "$inData" "$wd"/tpl-"$in_space"_hemi-"$hemi"_den-"$in_den"k_desc-"$desc"."$gii_type".gii "$bbwDir"/spaces/tpl-bigbrain/tpl-bigbrain_hemi-"$hemi"_desc-Yeo2011_7Networks_N1000."$gii_type".gii
 		else
 			gii_type=shape
 			interp_res=trilinear


### PR DESCRIPTION
I tried to convert a parcellation (.annot file) in fsaverage space to the bigbrain space and I got the following error:
```
Input parameters:
              --in_space : fsaverage
              --out_space : bigbrain
              --bb_space : histological
              --wd : ../../data/parcellations
              --desc : economo_parcellation
              --in_vol : 
              --in_lh : lh_economo.annot
              --in_rh : rh_economo.annot
              --interp : nearest
              --out_type : surface
              --out_den : 32
              --out_res : 
Traceback (most recent call last):
  File "env/lib/python3.7/site-packages/nibabel/loadsave.py", line 42, in load
    stat_result = os.stat(filename)
FileNotFoundError: [Errno 2] No such file or directory: '../tools/BigBrainWarp/spaces/tpl-bigbrain/tpl-bigbrain_hemi-L_desc-Yeo2011_7Networks_N1000.label.label.gii'
```
The problem was that ```fsaverage_to_bigbrain.sh``` points to ```tpl-bigbrain_hemi-L_desc-Yeo2011_7Networks_N1000.label.label.gii``` as the reference space, and it has an extra ```.label``` compared to the actual filename in the ```spaces/tpl-bigbrain``` directory. Here, I have simply removed the extra ```.label``` where needed.