### PR TITLE
Fix error in annot to Gifti conversion

### DIFF
--- a/scripts/annot2gii.py
+++ b/scripts/annot2gii.py
@@ -7,7 +7,7 @@ outName=str(sys.argv[2])
 refName=str(sys.argv[3])
 
 # read data
-values = nibabel.freesurfer.io.read_annot(inName)
+values, _, _ = nibabel.freesurfer.io.read_annot(inName)
 
 # load reference gifti
 refGifti = nibabel.load(refName)


### PR DESCRIPTION
While transforming an annot file from fsaverage to the bigbrain space I got the following error:
```
Input parameters:
              --in_space : fsaverage
              --out_space : bigbrain
              --bb_space : histological
              --wd : ../../data/parcellations
              --desc : economo_parcellation
              --in_vol : 
              --in_lh : lh_economo.annot
              --in_rh : rh_economo.annot
              --interp : nearest
              --out_type : surface
              --out_den : 32
              --out_res : 
Traceback (most recent call last):
  File "../tools/BigBrainWarp/scripts/annot2gii.py", line 17, in <module>
    outGifti.darrays[0].data = np.float32(values)
ValueError: setting an array element with a sequence. The requested array has an inhomogeneous shape after 1 dimensions. The detected shape was (3,) + inhomogeneous part.
```
The problem is that in the original code of ```annot2gii.py```, ```values``` will be a tuple and not a numpy array, since [```nibabel.freesurfer.io.read_annot```](https://nipy.org/nibabel/reference/nibabel.freesurfer.html#nibabel.freesurfer.io.read_annot) returns three variables (```labels```, ```ctab``` and ```names```). I'm using nibabel v. 3.2.1 but the function seems to behave the same in the previous versions. 
This error is fixed by assigning ```values``` to the first output of ```read_annot``` and ignoring its two other outputs.