### PR TITLE
Fixed incorrect usage of gunzip

### DIFF
--- a/scripts/bigbrain_to_icbm.sh
+++ b/scripts/bigbrain_to_icbm.sh
@@ -21,7 +21,7 @@ if [[ "$extension" == "mnc" ]] ; then
 	cp "$in_vol" "$wd"/tpl-bigbrain_desc-"$desc"_"$bb_space".mnc
 elif [[ "$extension" == "gz" ]] ; then
 	file_name=""$file_name%.*""
-	gunzip "$in_vol" "$wd"/tpl-bigbrain_desc-"$desc"_"$bb_space".nii
+	gunzip -c "$in_vol" > "$wd"/tpl-bigbrain_desc-"$desc"_"$bb_space".nii
 	nii2mnc "$wd"/tpl-bigbrain_desc-"$desc"_"$bb_space".nii "$wd"/tpl-bigbrain_desc-"$desc"_"$bb_space".mnc
 elif [[ "$extension" == "nii" ]] ; then
 	echo "transforming nii to mnc"

--- a/scripts/bigbrainvol_to_fsaverage.sh
+++ b/scripts/bigbrainvol_to_fsaverage.sh
@@ -26,7 +26,7 @@ if [[ "$extension" == "mnc" ]] ; then
    	mnc2nii "$in_vol" "$wd"/tpl-bigbrain_desc-"$desc".nii
 elif [[ "$extension" == "gz" ]] ; then
 	file_name=""$file_name%.*""
-	gunzip "$in_vol" "$wd"/tpl-bigbrain_desc-"$desc".nii
+	gunzip -c "$in_vol" > "$wd"/tpl-bigbrain_desc-"$desc".nii
 elif [[ "$extension" == "nii" ]] ; then
 	cp "$in_vol" "$wd"/tpl-bigbrain_desc-"$desc".nii
 else

--- a/scripts/icbm_to_bigbrain.sh
+++ b/scripts/icbm_to_bigbrain.sh
@@ -28,7 +28,7 @@ elif [[ "$extension" == "nii" ]] ; then
 elif [[ "$extension" == "gz" ]] ; then
 	echo "transforming nii to mnc"
 	file_name=""$file_name%.*""
-	gunzip "$in_vol" "$wd"/tpl-icbm_desc-"$desc".nii
+	gunzip -c "$in_vol" > "$wd"/tpl-icbm_desc-"$desc".nii
 	if [[ -f "$wd"/tpl-icbm_desc-"$desc".mnc ]] ; then
 		rm "$wd"/tpl-icbm_desc-"$desc".mnc
 	fi

--- a/scripts/icbm_to_bigbrainsurf.sh
+++ b/scripts/icbm_to_bigbrainsurf.sh
@@ -21,7 +21,7 @@ if [[ "$extension" == "mnc" ]] ; then
    	mnc2nii "$in_vol" "$wd"/tpl-icbm_desc-"$desc".nii
 elif [[ "$extension" == "gz" ]] ; then
 	file_name=""$file_name%.*""
-	gunzip "$in_vol" "$wd"/tpl-icbm_desc-"$desc".nii
+	gunzip -c "$in_vol" > "$wd"/tpl-icbm_desc-"$desc".nii
 elif [[ "$extension" == "nii" ]] ; then
 	cp "$in_vol" "$wd"/tpl-icbm_desc-"$desc".nii
 else


### PR DESCRIPTION
Good morning,

I noticed that BigBrainWarp does not seem to call `gunzip` correctly when passed volumes are in `.nii.gz` format. This PR should fix this.